### PR TITLE
Imperial/metric contours

### DIFF
--- a/style-aerial-png.json
+++ b/style-aerial-png.json
@@ -233,7 +233,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -252,6 +252,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -270,7 +271,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -289,6 +290,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -1498,7 +1500,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_ft}ft",
         "text-font": ["Open Sans Regular"],
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1528,7 +1530,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
-        "visibility": "visible"
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1800,7 +1802,7 @@
         "text-size": 11,
         "icon-allow-overlap": false,
         "icon-size": {"stops": [[14, 0.65], [16, 1]]},
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1838,7 +1840,8 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "icon-size": {"stops": [[14, 0.65], [16, 1]]}
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1877,7 +1880,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1915,7 +1918,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1954,7 +1958,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1992,7 +1996,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",

--- a/style-aerial-png.json
+++ b/style-aerial-png.json
@@ -33,9 +33,17 @@
       "maxzoom": 12,
       "encoding": "mapbox"
     },
-    "contours": {
+    "contour_10m": {
       "type": "vector",
-      "url": "https://tiles.nst.guide/contours/tile.json"
+      "tiles": ["https://tiles.nst.guide/contour_10m/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
+    },
+    "contour_40ft": {
+      "type": "vector",
+      "tiles": ["https://tiles.nst.guide/contour_40ft/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
     }
   },
   "sprite": "https://raw.githubusercontent.com/nst-guide/osm-liberty-topo/gh-pages/sprites/osm-liberty-topo",
@@ -214,31 +222,77 @@
       }
     },
     {
-      "id": "contour",
+      "id": "contour_index_ft",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
-      "minzoom": 7,
-      "filter": ["all", ["==", "FCode", 10101], [">", "ContourElevation", 0]],
-      "layout": {"visibility": "visible"},
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 0,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
       "paint": {
-        "line-color": "rgb(179, 134, 89)",
-        "line-opacity": {"stops": [[11, 0.2], [15, 0.5]]},
-        "line-width": {"stops": [[11, 0.4], [14, 0.7]]}
+        "line-color": "rgb(166, 116, 66)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": 1.1
       }
     },
     {
-      "id": "contour_index",
+      "id": "contour_index_m",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
       "minzoom": 0,
-      "filter": ["all", [">", "ContourElevation", 0], ["==", "FCode", 10102]],
-      "layout": {"visibility": "visible"},
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
       "paint": {
         "line-color": "rgb(166, 116, 66)",
-        "line-opacity": {"stops": [[11, 0.2], [15, 0.6]]},
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
         "line-width": 1.1
+      }
+    },
+    {
+      "id": "contour_ft",
+      "type": "line",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
+      }
+    },
+    {
+      "id": "contour_m",
+      "type": "line",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
       }
     },
     {
@@ -1423,26 +1477,56 @@
       }
     },
     {
-      "id": "contour_label",
+      "id": "contour_label_ft",
       "type": "symbol",
       "metadata": {},
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
       "filter": [
-        "all",
-        ["==", "$type", "LineString"],
-        ["==", "FCode", 10102],
-        [">", "ContourElevation", 0]
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
       "layout": {
-        "text-size": {"base": 1, "stops": [[15, 10], [20, 12]]},
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
         "text-allow-overlap": false,
         "symbol-avoid-edges": true,
         "text-ignore-placement": false,
         "symbol-placement": "line",
         "text-padding": 10,
         "text-rotation-alignment": "map",
-        "text-field": "{ContourElevation}",
+        "text-field": "{ele_ft}ft",
+        "text-font": ["Open Sans Regular"],
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgb(131, 66, 37)",
+        "text-halo-color": "hsla(0, 0%, 100%, 0.5)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "contour_label_m",
+      "type": "symbol",
+      "metadata": {},
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "layout": {
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
+        "text-allow-overlap": false,
+        "symbol-avoid-edges": true,
+        "text-ignore-placement": false,
+        "symbol-placement": "line",
+        "text-padding": 10,
+        "text-rotation-alignment": "map",
+        "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
         "visibility": "visible"
       },
@@ -1687,7 +1771,7 @@
       }
     },
     {
-      "id": "poi_saddle",
+      "id": "poi_saddle_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1704,7 +1788,46 @@
             ["get", "name"],
             "\n",
             ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-            " ft"
+            "ft"
+          ],
+          ["has", "name"],
+          ["get", "name"],
+          "Pass"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_saddle_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 13,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "saddle"]],
+      "layout": {
+        "icon-image": "viewpoint_11",
+        "text-anchor": "top",
+        "text-field": [
+          "case",
+          ["all", ["has", "name"], ["has", "ele"]],
+          [
+            "concat",
+            ["get", "name"],
+            "\n",
+            ["to-string", ["round", ["get", "ele"]]],
+            "m"
           ],
           ["has", "name"],
           ["get", "name"],
@@ -1725,7 +1848,7 @@
       }
     },
     {
-      "id": "poi_peak_rank1",
+      "id": "poi_peak_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1747,7 +1870,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_peak_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "peak"]
+      ],
+      "layout": {
+        "icon-image": "mountain_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,
@@ -1763,7 +1925,7 @@
       }
     },
     {
-      "id": "poi_volcano_rank1",
+      "id": "poi_volcano_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1785,7 +1947,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_volcano_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "volcano"]
+      ],
+      "layout": {
+        "icon-image": "volcano_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,

--- a/style-aerial.json
+++ b/style-aerial.json
@@ -233,7 +233,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -252,6 +252,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -270,7 +271,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -289,6 +290,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -1498,7 +1500,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_ft}ft",
         "text-font": ["Open Sans Regular"],
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1528,7 +1530,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
-        "visibility": "visible"
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1800,7 +1802,7 @@
         "text-size": 11,
         "icon-allow-overlap": false,
         "icon-size": {"stops": [[14, 0.65], [16, 1]]},
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1838,7 +1840,8 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "icon-size": {"stops": [[14, 0.65], [16, 1]]}
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1877,7 +1880,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1915,7 +1918,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1954,7 +1958,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1992,7 +1996,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",

--- a/style-aerial.json
+++ b/style-aerial.json
@@ -33,9 +33,17 @@
       "maxzoom": 12,
       "encoding": "mapbox"
     },
-    "contours": {
+    "contour_10m": {
       "type": "vector",
-      "url": "https://tiles.nst.guide/contours/tile.json"
+      "tiles": ["https://tiles.nst.guide/contour_10m/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
+    },
+    "contour_40ft": {
+      "type": "vector",
+      "tiles": ["https://tiles.nst.guide/contour_40ft/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
     }
   },
   "sprite": "https://raw.githubusercontent.com/nst-guide/osm-liberty-topo/gh-pages/sprites/osm-liberty-topo",
@@ -214,31 +222,77 @@
       }
     },
     {
-      "id": "contour",
+      "id": "contour_index_ft",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
-      "minzoom": 7,
-      "filter": ["all", ["==", "FCode", 10101], [">", "ContourElevation", 0]],
-      "layout": {"visibility": "visible"},
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 0,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
       "paint": {
-        "line-color": "rgb(179, 134, 89)",
-        "line-opacity": {"stops": [[11, 0.2], [15, 0.5]]},
-        "line-width": {"stops": [[11, 0.4], [14, 0.7]]}
+        "line-color": "rgb(166, 116, 66)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": 1.1
       }
     },
     {
-      "id": "contour_index",
+      "id": "contour_index_m",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
       "minzoom": 0,
-      "filter": ["all", [">", "ContourElevation", 0], ["==", "FCode", 10102]],
-      "layout": {"visibility": "visible"},
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
       "paint": {
         "line-color": "rgb(166, 116, 66)",
-        "line-opacity": {"stops": [[11, 0.2], [15, 0.6]]},
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
         "line-width": 1.1
+      }
+    },
+    {
+      "id": "contour_ft",
+      "type": "line",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
+      }
+    },
+    {
+      "id": "contour_m",
+      "type": "line",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
       }
     },
     {
@@ -1423,26 +1477,56 @@
       }
     },
     {
-      "id": "contour_label",
+      "id": "contour_label_ft",
       "type": "symbol",
       "metadata": {},
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
       "filter": [
-        "all",
-        ["==", "$type", "LineString"],
-        ["==", "FCode", 10102],
-        [">", "ContourElevation", 0]
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
       "layout": {
-        "text-size": {"base": 1, "stops": [[15, 10], [20, 12]]},
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
         "text-allow-overlap": false,
         "symbol-avoid-edges": true,
         "text-ignore-placement": false,
         "symbol-placement": "line",
         "text-padding": 10,
         "text-rotation-alignment": "map",
-        "text-field": "{ContourElevation}",
+        "text-field": "{ele_ft}ft",
+        "text-font": ["Open Sans Regular"],
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgb(131, 66, 37)",
+        "text-halo-color": "hsla(0, 0%, 100%, 0.5)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "contour_label_m",
+      "type": "symbol",
+      "metadata": {},
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "layout": {
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
+        "text-allow-overlap": false,
+        "symbol-avoid-edges": true,
+        "text-ignore-placement": false,
+        "symbol-placement": "line",
+        "text-padding": 10,
+        "text-rotation-alignment": "map",
+        "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
         "visibility": "visible"
       },
@@ -1687,7 +1771,7 @@
       }
     },
     {
-      "id": "poi_saddle",
+      "id": "poi_saddle_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1704,7 +1788,46 @@
             ["get", "name"],
             "\n",
             ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-            " ft"
+            "ft"
+          ],
+          ["has", "name"],
+          ["get", "name"],
+          "Pass"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_saddle_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 13,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "saddle"]],
+      "layout": {
+        "icon-image": "viewpoint_11",
+        "text-anchor": "top",
+        "text-field": [
+          "case",
+          ["all", ["has", "name"], ["has", "ele"]],
+          [
+            "concat",
+            ["get", "name"],
+            "\n",
+            ["to-string", ["round", ["get", "ele"]]],
+            "m"
           ],
           ["has", "name"],
           ["get", "name"],
@@ -1725,7 +1848,7 @@
       }
     },
     {
-      "id": "poi_peak_rank1",
+      "id": "poi_peak_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1747,7 +1870,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_peak_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "peak"]
+      ],
+      "layout": {
+        "icon-image": "mountain_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,
@@ -1763,7 +1925,7 @@
       }
     },
     {
-      "id": "poi_volcano_rank1",
+      "id": "poi_volcano_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1785,7 +1947,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_volcano_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "volcano"]
+      ],
+      "layout": {
+        "icon-image": "volcano_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,

--- a/style-fstopo-png.json
+++ b/style-fstopo-png.json
@@ -20,7 +20,7 @@
     },
     "fstopo": {
       "minzoom": 4,
-      "maxzoom": 16,
+      "maxzoom": 15,
       "tileSize": 512,
       "tiles": ["https://tiles.nst.guide/fstopo-png/{z}/{x}/{y}.png"],
       "type": "raster",

--- a/style-fstopo-png.json
+++ b/style-fstopo-png.json
@@ -33,9 +33,17 @@
       "maxzoom": 12,
       "encoding": "mapbox"
     },
-    "contours": {
+    "contour_10m": {
       "type": "vector",
-      "url": "https://tiles.nst.guide/contours/tile.json"
+      "tiles": ["https://tiles.nst.guide/contour_10m/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
+    },
+    "contour_40ft": {
+      "type": "vector",
+      "tiles": ["https://tiles.nst.guide/contour_40ft/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
     }
   },
   "sprite": "https://raw.githubusercontent.com/nst-guide/osm-liberty-topo/gh-pages/sprites/osm-liberty-topo",
@@ -202,31 +210,77 @@
       }
     },
     {
-      "id": "contour",
+      "id": "contour_index_ft",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
-      "minzoom": 7,
-      "filter": ["all", ["==", "FCode", 10101], [">", "ContourElevation", 0]],
-      "layout": {"visibility": "visible"},
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 0,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
       "paint": {
-        "line-color": "rgb(179, 134, 89)",
-        "line-opacity": {"stops": [[11, 0.2], [15, 0.5]]},
-        "line-width": {"stops": [[11, 0.4], [14, 0.7]]}
+        "line-color": "rgb(166, 116, 66)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": 1.1
       }
     },
     {
-      "id": "contour_index",
+      "id": "contour_index_m",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
       "minzoom": 0,
-      "filter": ["all", [">", "ContourElevation", 0], ["==", "FCode", 10102]],
-      "layout": {"visibility": "visible"},
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
       "paint": {
         "line-color": "rgb(166, 116, 66)",
-        "line-opacity": {"stops": [[11, 0.2], [15, 0.6]]},
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
         "line-width": 1.1
+      }
+    },
+    {
+      "id": "contour_ft",
+      "type": "line",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
+      }
+    },
+    {
+      "id": "contour_m",
+      "type": "line",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
       }
     },
     {
@@ -1411,26 +1465,56 @@
       }
     },
     {
-      "id": "contour_label",
+      "id": "contour_label_ft",
       "type": "symbol",
       "metadata": {},
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
       "filter": [
-        "all",
-        ["==", "$type", "LineString"],
-        ["==", "FCode", 10102],
-        [">", "ContourElevation", 0]
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
       "layout": {
-        "text-size": {"base": 1, "stops": [[15, 10], [20, 12]]},
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
         "text-allow-overlap": false,
         "symbol-avoid-edges": true,
         "text-ignore-placement": false,
         "symbol-placement": "line",
         "text-padding": 10,
         "text-rotation-alignment": "map",
-        "text-field": "{ContourElevation}",
+        "text-field": "{ele_ft}ft",
+        "text-font": ["Open Sans Regular"],
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgb(131, 66, 37)",
+        "text-halo-color": "hsla(0, 0%, 100%, 0.5)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "contour_label_m",
+      "type": "symbol",
+      "metadata": {},
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "layout": {
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
+        "text-allow-overlap": false,
+        "symbol-avoid-edges": true,
+        "text-ignore-placement": false,
+        "symbol-placement": "line",
+        "text-padding": 10,
+        "text-rotation-alignment": "map",
+        "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
         "visibility": "visible"
       },
@@ -1675,7 +1759,7 @@
       }
     },
     {
-      "id": "poi_saddle",
+      "id": "poi_saddle_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1692,7 +1776,46 @@
             ["get", "name"],
             "\n",
             ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-            " ft"
+            "ft"
+          ],
+          ["has", "name"],
+          ["get", "name"],
+          "Pass"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_saddle_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 13,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "saddle"]],
+      "layout": {
+        "icon-image": "viewpoint_11",
+        "text-anchor": "top",
+        "text-field": [
+          "case",
+          ["all", ["has", "name"], ["has", "ele"]],
+          [
+            "concat",
+            ["get", "name"],
+            "\n",
+            ["to-string", ["round", ["get", "ele"]]],
+            "m"
           ],
           ["has", "name"],
           ["get", "name"],
@@ -1713,7 +1836,7 @@
       }
     },
     {
-      "id": "poi_peak_rank1",
+      "id": "poi_peak_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1735,7 +1858,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_peak_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "peak"]
+      ],
+      "layout": {
+        "icon-image": "mountain_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,
@@ -1751,7 +1913,7 @@
       }
     },
     {
-      "id": "poi_volcano_rank1",
+      "id": "poi_volcano_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1773,7 +1935,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_volcano_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "volcano"]
+      ],
+      "layout": {
+        "icon-image": "volcano_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,

--- a/style-fstopo-png.json
+++ b/style-fstopo-png.json
@@ -221,7 +221,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -240,6 +240,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -258,7 +259,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -277,6 +278,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -1486,7 +1488,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_ft}ft",
         "text-font": ["Open Sans Regular"],
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1516,7 +1518,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
-        "visibility": "visible"
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1788,7 +1790,7 @@
         "text-size": 11,
         "icon-allow-overlap": false,
         "icon-size": {"stops": [[14, 0.65], [16, 1]]},
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1826,7 +1828,8 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "icon-size": {"stops": [[14, 0.65], [16, 1]]}
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1865,7 +1868,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1903,7 +1906,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1942,7 +1946,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1980,7 +1984,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",

--- a/style-fstopo.json
+++ b/style-fstopo.json
@@ -33,9 +33,17 @@
       "maxzoom": 12,
       "encoding": "mapbox"
     },
-    "contours": {
+    "contour_10m": {
       "type": "vector",
-      "url": "https://tiles.nst.guide/contours/tile.json"
+      "tiles": ["https://tiles.nst.guide/contour_10m/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
+    },
+    "contour_40ft": {
+      "type": "vector",
+      "tiles": ["https://tiles.nst.guide/contour_40ft/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
     }
   },
   "sprite": "https://raw.githubusercontent.com/nst-guide/osm-liberty-topo/gh-pages/sprites/osm-liberty-topo",
@@ -202,31 +210,77 @@
       }
     },
     {
-      "id": "contour",
+      "id": "contour_index_ft",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
-      "minzoom": 7,
-      "filter": ["all", ["==", "FCode", 10101], [">", "ContourElevation", 0]],
-      "layout": {"visibility": "visible"},
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 0,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
       "paint": {
-        "line-color": "rgb(179, 134, 89)",
-        "line-opacity": {"stops": [[11, 0.2], [15, 0.5]]},
-        "line-width": {"stops": [[11, 0.4], [14, 0.7]]}
+        "line-color": "rgb(166, 116, 66)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": 1.1
       }
     },
     {
-      "id": "contour_index",
+      "id": "contour_index_m",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
       "minzoom": 0,
-      "filter": ["all", [">", "ContourElevation", 0], ["==", "FCode", 10102]],
-      "layout": {"visibility": "visible"},
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
       "paint": {
         "line-color": "rgb(166, 116, 66)",
-        "line-opacity": {"stops": [[11, 0.2], [15, 0.6]]},
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
         "line-width": 1.1
+      }
+    },
+    {
+      "id": "contour_ft",
+      "type": "line",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
+      }
+    },
+    {
+      "id": "contour_m",
+      "type": "line",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
       }
     },
     {
@@ -1411,26 +1465,56 @@
       }
     },
     {
-      "id": "contour_label",
+      "id": "contour_label_ft",
       "type": "symbol",
       "metadata": {},
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
       "filter": [
-        "all",
-        ["==", "$type", "LineString"],
-        ["==", "FCode", 10102],
-        [">", "ContourElevation", 0]
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
       "layout": {
-        "text-size": {"base": 1, "stops": [[15, 10], [20, 12]]},
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
         "text-allow-overlap": false,
         "symbol-avoid-edges": true,
         "text-ignore-placement": false,
         "symbol-placement": "line",
         "text-padding": 10,
         "text-rotation-alignment": "map",
-        "text-field": "{ContourElevation}",
+        "text-field": "{ele_ft}ft",
+        "text-font": ["Open Sans Regular"],
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgb(131, 66, 37)",
+        "text-halo-color": "hsla(0, 0%, 100%, 0.5)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "contour_label_m",
+      "type": "symbol",
+      "metadata": {},
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "layout": {
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
+        "text-allow-overlap": false,
+        "symbol-avoid-edges": true,
+        "text-ignore-placement": false,
+        "symbol-placement": "line",
+        "text-padding": 10,
+        "text-rotation-alignment": "map",
+        "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
         "visibility": "visible"
       },
@@ -1675,7 +1759,7 @@
       }
     },
     {
-      "id": "poi_saddle",
+      "id": "poi_saddle_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1692,7 +1776,46 @@
             ["get", "name"],
             "\n",
             ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-            " ft"
+            "ft"
+          ],
+          ["has", "name"],
+          ["get", "name"],
+          "Pass"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_saddle_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 13,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "saddle"]],
+      "layout": {
+        "icon-image": "viewpoint_11",
+        "text-anchor": "top",
+        "text-field": [
+          "case",
+          ["all", ["has", "name"], ["has", "ele"]],
+          [
+            "concat",
+            ["get", "name"],
+            "\n",
+            ["to-string", ["round", ["get", "ele"]]],
+            "m"
           ],
           ["has", "name"],
           ["get", "name"],
@@ -1713,7 +1836,7 @@
       }
     },
     {
-      "id": "poi_peak_rank1",
+      "id": "poi_peak_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1735,7 +1858,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_peak_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "peak"]
+      ],
+      "layout": {
+        "icon-image": "mountain_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,
@@ -1751,7 +1913,7 @@
       }
     },
     {
-      "id": "poi_volcano_rank1",
+      "id": "poi_volcano_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1773,7 +1935,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_volcano_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "volcano"]
+      ],
+      "layout": {
+        "icon-image": "volcano_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,

--- a/style-fstopo.json
+++ b/style-fstopo.json
@@ -221,7 +221,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -240,6 +240,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -258,7 +259,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -277,6 +278,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -1486,7 +1488,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_ft}ft",
         "text-font": ["Open Sans Regular"],
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1516,7 +1518,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
-        "visibility": "visible"
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1788,7 +1790,7 @@
         "text-size": 11,
         "icon-allow-overlap": false,
         "icon-size": {"stops": [[14, 0.65], [16, 1]]},
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1826,7 +1828,8 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "icon-size": {"stops": [[14, 0.65], [16, 1]]}
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1865,7 +1868,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1903,7 +1906,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1942,7 +1946,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1980,7 +1984,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",

--- a/style-fstopo.json
+++ b/style-fstopo.json
@@ -20,7 +20,7 @@
     },
     "fstopo": {
       "minzoom": 4,
-      "maxzoom": 16,
+      "maxzoom": 15,
       "tileSize": 512,
       "tiles": ["https://tiles.nst.guide/fstopo-webp/{z}/{x}/{y}.png"],
       "type": "raster",

--- a/style-hybrid-png.json
+++ b/style-hybrid-png.json
@@ -241,7 +241,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -260,6 +260,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -278,7 +279,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -297,6 +298,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -1507,7 +1509,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_ft}ft",
         "text-font": ["Open Sans Regular"],
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1537,7 +1539,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
-        "visibility": "visible"
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1809,7 +1811,7 @@
         "text-size": 11,
         "icon-allow-overlap": false,
         "icon-size": {"stops": [[14, 0.65], [16, 1]]},
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1847,7 +1849,8 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "icon-size": {"stops": [[14, 0.65], [16, 1]]}
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1886,7 +1889,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1924,7 +1927,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1963,7 +1967,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -2001,7 +2005,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",

--- a/style-hybrid-png.json
+++ b/style-hybrid-png.json
@@ -33,9 +33,17 @@
       "maxzoom": 12,
       "encoding": "mapbox"
     },
-    "contours": {
+    "contour_10m": {
       "type": "vector",
-      "url": "https://tiles.nst.guide/contours/tile.json"
+      "tiles": ["https://tiles.nst.guide/contour_10m/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
+    },
+    "contour_40ft": {
+      "type": "vector",
+      "tiles": ["https://tiles.nst.guide/contour_40ft/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
     }
   },
   "sprite": "https://raw.githubusercontent.com/nst-guide/osm-liberty-topo/gh-pages/sprites/osm-liberty-topo",
@@ -222,31 +230,77 @@
       }
     },
     {
-      "id": "contour",
+      "id": "contour_index_ft",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
-      "minzoom": 7,
-      "filter": ["all", ["==", "FCode", 10101], [">", "ContourElevation", 0]],
-      "layout": {"visibility": "visible"},
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 0,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
       "paint": {
-        "line-color": "rgba(157, 111, 66, 1)",
-        "line-opacity": {"stops": [[11, 0.2], [15, 0.9]]},
-        "line-width": {"stops": [[11, 0.3], [19, 1.2]]}
+        "line-color": "rgb(166, 116, 66)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": 1.1
       }
     },
     {
-      "id": "contour_index",
+      "id": "contour_index_m",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
       "minzoom": 0,
-      "filter": ["all", [">", "ContourElevation", 0], ["==", "FCode", 10102]],
-      "layout": {"visibility": "visible"},
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
       "paint": {
         "line-color": "rgb(166, 116, 66)",
-        "line-opacity": {"stops": [[11, 0.3], [15, 0.9]]},
-        "line-width": {"stops": [[11, 0.9], [18, 2.1]]}
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": 1.1
+      }
+    },
+    {
+      "id": "contour_ft",
+      "type": "line",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
+      }
+    },
+    {
+      "id": "contour_m",
+      "type": "line",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
       }
     },
     {
@@ -1432,26 +1486,56 @@
       }
     },
     {
-      "id": "contour_label",
+      "id": "contour_label_ft",
       "type": "symbol",
       "metadata": {},
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
       "filter": [
-        "all",
-        ["==", "$type", "LineString"],
-        ["==", "FCode", 10102],
-        [">", "ContourElevation", 0]
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
       "layout": {
-        "text-size": {"base": 1, "stops": [[15, 10], [20, 12]]},
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
         "text-allow-overlap": false,
         "symbol-avoid-edges": true,
         "text-ignore-placement": false,
         "symbol-placement": "line",
         "text-padding": 10,
         "text-rotation-alignment": "map",
-        "text-field": "{ContourElevation}",
+        "text-field": "{ele_ft}ft",
+        "text-font": ["Open Sans Regular"],
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgb(131, 66, 37)",
+        "text-halo-color": "hsla(0, 0%, 100%, 0.5)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "contour_label_m",
+      "type": "symbol",
+      "metadata": {},
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "layout": {
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
+        "text-allow-overlap": false,
+        "symbol-avoid-edges": true,
+        "text-ignore-placement": false,
+        "symbol-placement": "line",
+        "text-padding": 10,
+        "text-rotation-alignment": "map",
+        "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
         "visibility": "visible"
       },
@@ -1696,7 +1780,7 @@
       }
     },
     {
-      "id": "poi_saddle",
+      "id": "poi_saddle_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1713,7 +1797,46 @@
             ["get", "name"],
             "\n",
             ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-            " ft"
+            "ft"
+          ],
+          ["has", "name"],
+          ["get", "name"],
+          "Pass"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_saddle_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 13,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "saddle"]],
+      "layout": {
+        "icon-image": "viewpoint_11",
+        "text-anchor": "top",
+        "text-field": [
+          "case",
+          ["all", ["has", "name"], ["has", "ele"]],
+          [
+            "concat",
+            ["get", "name"],
+            "\n",
+            ["to-string", ["round", ["get", "ele"]]],
+            "m"
           ],
           ["has", "name"],
           ["get", "name"],
@@ -1734,7 +1857,7 @@
       }
     },
     {
-      "id": "poi_peak_rank1",
+      "id": "poi_peak_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1756,7 +1879,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_peak_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "peak"]
+      ],
+      "layout": {
+        "icon-image": "mountain_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,
@@ -1772,7 +1934,7 @@
       }
     },
     {
-      "id": "poi_volcano_rank1",
+      "id": "poi_volcano_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1794,7 +1956,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_volcano_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "volcano"]
+      ],
+      "layout": {
+        "icon-image": "volcano_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,

--- a/style-hybrid.json
+++ b/style-hybrid.json
@@ -241,7 +241,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -260,6 +260,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -278,7 +279,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -297,6 +298,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -1507,7 +1509,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_ft}ft",
         "text-font": ["Open Sans Regular"],
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1537,7 +1539,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
-        "visibility": "visible"
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1809,7 +1811,7 @@
         "text-size": 11,
         "icon-allow-overlap": false,
         "icon-size": {"stops": [[14, 0.65], [16, 1]]},
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1847,7 +1849,8 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "icon-size": {"stops": [[14, 0.65], [16, 1]]}
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1886,7 +1889,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1924,7 +1927,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1963,7 +1967,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -2001,7 +2005,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",

--- a/style-hybrid.json
+++ b/style-hybrid.json
@@ -33,9 +33,17 @@
       "maxzoom": 12,
       "encoding": "mapbox"
     },
-    "contours": {
+    "contour_10m": {
       "type": "vector",
-      "url": "https://tiles.nst.guide/contours/tile.json"
+      "tiles": ["https://tiles.nst.guide/contour_10m/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
+    },
+    "contour_40ft": {
+      "type": "vector",
+      "tiles": ["https://tiles.nst.guide/contour_40ft/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
     }
   },
   "sprite": "https://raw.githubusercontent.com/nst-guide/osm-liberty-topo/gh-pages/sprites/osm-liberty-topo",
@@ -222,31 +230,77 @@
       }
     },
     {
-      "id": "contour",
+      "id": "contour_index_ft",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
-      "minzoom": 7,
-      "filter": ["all", ["==", "FCode", 10101], [">", "ContourElevation", 0]],
-      "layout": {"visibility": "visible"},
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 0,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
       "paint": {
-        "line-color": "rgba(157, 111, 66, 1)",
-        "line-opacity": {"stops": [[11, 0.2], [15, 0.9]]},
-        "line-width": {"stops": [[11, 0.3], [19, 1.2]]}
+        "line-color": "rgb(166, 116, 66)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": 1.1
       }
     },
     {
-      "id": "contour_index",
+      "id": "contour_index_m",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
       "minzoom": 0,
-      "filter": ["all", [">", "ContourElevation", 0], ["==", "FCode", 10102]],
-      "layout": {"visibility": "visible"},
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
       "paint": {
         "line-color": "rgb(166, 116, 66)",
-        "line-opacity": {"stops": [[11, 0.3], [15, 0.9]]},
-        "line-width": {"stops": [[11, 0.9], [18, 2.1]]}
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": 1.1
+      }
+    },
+    {
+      "id": "contour_ft",
+      "type": "line",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
+      }
+    },
+    {
+      "id": "contour_m",
+      "type": "line",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
       }
     },
     {
@@ -1432,26 +1486,56 @@
       }
     },
     {
-      "id": "contour_label",
+      "id": "contour_label_ft",
       "type": "symbol",
       "metadata": {},
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
       "filter": [
-        "all",
-        ["==", "$type", "LineString"],
-        ["==", "FCode", 10102],
-        [">", "ContourElevation", 0]
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
       "layout": {
-        "text-size": {"base": 1, "stops": [[15, 10], [20, 12]]},
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
         "text-allow-overlap": false,
         "symbol-avoid-edges": true,
         "text-ignore-placement": false,
         "symbol-placement": "line",
         "text-padding": 10,
         "text-rotation-alignment": "map",
-        "text-field": "{ContourElevation}",
+        "text-field": "{ele_ft}ft",
+        "text-font": ["Open Sans Regular"],
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgb(131, 66, 37)",
+        "text-halo-color": "hsla(0, 0%, 100%, 0.5)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "contour_label_m",
+      "type": "symbol",
+      "metadata": {},
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "layout": {
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
+        "text-allow-overlap": false,
+        "symbol-avoid-edges": true,
+        "text-ignore-placement": false,
+        "symbol-placement": "line",
+        "text-padding": 10,
+        "text-rotation-alignment": "map",
+        "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
         "visibility": "visible"
       },
@@ -1696,7 +1780,7 @@
       }
     },
     {
-      "id": "poi_saddle",
+      "id": "poi_saddle_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1713,7 +1797,46 @@
             ["get", "name"],
             "\n",
             ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-            " ft"
+            "ft"
+          ],
+          ["has", "name"],
+          ["get", "name"],
+          "Pass"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_saddle_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 13,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "saddle"]],
+      "layout": {
+        "icon-image": "viewpoint_11",
+        "text-anchor": "top",
+        "text-field": [
+          "case",
+          ["all", ["has", "name"], ["has", "ele"]],
+          [
+            "concat",
+            ["get", "name"],
+            "\n",
+            ["to-string", ["round", ["get", "ele"]]],
+            "m"
           ],
           ["has", "name"],
           ["get", "name"],
@@ -1734,7 +1857,7 @@
       }
     },
     {
-      "id": "poi_peak_rank1",
+      "id": "poi_peak_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1756,7 +1879,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_peak_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "peak"]
+      ],
+      "layout": {
+        "icon-image": "mountain_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,
@@ -1772,7 +1934,7 @@
       }
     },
     {
-      "id": "poi_volcano_rank1",
+      "id": "poi_volcano_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1794,7 +1956,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_volcano_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "volcano"]
+      ],
+      "layout": {
+        "icon-image": "volcano_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,

--- a/style-png.json
+++ b/style-png.json
@@ -153,7 +153,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -172,6 +172,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -190,7 +191,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -209,6 +210,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -1489,7 +1491,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_ft}ft",
         "text-font": ["Open Sans Regular"],
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1519,7 +1521,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
-        "visibility": "visible"
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1791,7 +1793,7 @@
         "text-size": 11,
         "icon-allow-overlap": false,
         "icon-size": {"stops": [[14, 0.65], [16, 1]]},
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1829,7 +1831,8 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "icon-size": {"stops": [[14, 0.65], [16, 1]]}
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1868,7 +1871,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1906,7 +1909,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1945,7 +1949,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1983,7 +1987,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",

--- a/style-png.json
+++ b/style-png.json
@@ -25,9 +25,17 @@
       "maxzoom": 12,
       "encoding": "mapbox"
     },
-    "contours": {
+    "contour_10m": {
       "type": "vector",
-      "url": "https://tiles.nst.guide/contours/tile.json"
+      "tiles": ["https://tiles.nst.guide/contour_10m/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
+    },
+    "contour_40ft": {
+      "type": "vector",
+      "tiles": ["https://tiles.nst.guide/contour_40ft/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 13
     }
   },
   "sprite": "https://raw.githubusercontent.com/nst-guide/osm-liberty-topo/gh-pages/sprites/osm-liberty-topo",
@@ -134,13 +142,18 @@
       }
     },
     {
-      "id": "contour_index",
+      "id": "contour_index_ft",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
       "minzoom": 0,
-      "filter": ["all", [">", "ContourElevation", 0], ["==", "FCode", 10102]],
-      "layout": {"visibility": "visible"},
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -148,13 +161,54 @@
       }
     },
     {
-      "id": "contour",
+      "id": "contour_index_m",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
-      "minzoom": 7,
-      "filter": ["all", ["==", "FCode", 10101], [">", "ContourElevation", 0]],
-      "layout": {"visibility": "visible"},
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "minzoom": 0,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "paint": {
+        "line-color": "rgb(166, 116, 66)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": 1.1
+      }
+    },
+    {
+      "id": "contour_ft",
+      "type": "line",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
+      "layout": {"visibility": "none"},
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
+      }
+    },
+    {
+      "id": "contour_m",
+      "type": "line",
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
+      ],
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -1414,16 +1468,16 @@
       }
     },
     {
-      "id": "contour_label",
+      "id": "contour_label_ft",
       "type": "symbol",
       "metadata": {},
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_40ft",
+      "source-layer": "contour_40ft",
       "filter": [
-        "all",
-        ["==", "$type", "LineString"],
-        ["==", "FCode", 10102],
-        [">", "ContourElevation", 0]
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
       "layout": {
         "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
@@ -1433,7 +1487,37 @@
         "symbol-placement": "line",
         "text-padding": 10,
         "text-rotation-alignment": "map",
-        "text-field": "{ContourElevation}",
+        "text-field": "{ele_ft}ft",
+        "text-font": ["Open Sans Regular"],
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgb(131, 66, 37)",
+        "text-halo-color": "hsla(0, 0%, 100%, 0.5)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "contour_label_m",
+      "type": "symbol",
+      "metadata": {},
+      "source": "contour_10m",
+      "source-layer": "contour_10m",
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
+      "layout": {
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
+        "text-allow-overlap": false,
+        "symbol-avoid-edges": true,
+        "text-ignore-placement": false,
+        "symbol-placement": "line",
+        "text-padding": 10,
+        "text-rotation-alignment": "map",
+        "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
         "visibility": "visible"
       },
@@ -1678,7 +1762,7 @@
       }
     },
     {
-      "id": "poi_saddle",
+      "id": "poi_saddle_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1695,7 +1779,46 @@
             ["get", "name"],
             "\n",
             ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-            " ft"
+            "ft"
+          ],
+          ["has", "name"],
+          ["get", "name"],
+          "Pass"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_saddle_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 13,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "saddle"]],
+      "layout": {
+        "icon-image": "viewpoint_11",
+        "text-anchor": "top",
+        "text-field": [
+          "case",
+          ["all", ["has", "name"], ["has", "ele"]],
+          [
+            "concat",
+            ["get", "name"],
+            "\n",
+            ["to-string", ["round", ["get", "ele"]]],
+            "m"
           ],
           ["has", "name"],
           ["get", "name"],
@@ -1716,7 +1839,7 @@
       }
     },
     {
-      "id": "poi_peak_rank1",
+      "id": "poi_peak_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1738,7 +1861,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_peak_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "peak"]
+      ],
+      "layout": {
+        "icon-image": "mountain_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,
@@ -1754,7 +1916,7 @@
       }
     },
     {
-      "id": "poi_volcano_rank1",
+      "id": "poi_volcano_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1776,7 +1938,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_volcano_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "volcano"]
+      ],
+      "layout": {
+        "icon-image": "volcano_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,

--- a/style.json
+++ b/style.json
@@ -153,7 +153,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -172,6 +172,7 @@
         ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -190,7 +191,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
       ],
-      "layout": {"visibility": "none"},
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -209,6 +210,7 @@
         ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
         ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
       ],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -1489,7 +1491,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_ft}ft",
         "text-font": ["Open Sans Regular"],
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1519,7 +1521,7 @@
         "text-rotation-alignment": "map",
         "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
-        "visibility": "visible"
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgb(131, 66, 37)",
@@ -1791,7 +1793,7 @@
         "text-size": 11,
         "icon-allow-overlap": false,
         "icon-size": {"stops": [[14, 0.65], [16, 1]]},
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1829,7 +1831,8 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "icon-size": {"stops": [[14, 0.65], [16, 1]]}
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1868,7 +1871,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1906,7 +1909,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1945,7 +1949,7 @@
         "text-offset": [0, 0.6],
         "text-size": 11,
         "icon-allow-overlap": false,
-        "visibility": "none"
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",
@@ -1983,7 +1987,8 @@
         "text-max-width": 9,
         "text-offset": [0, 0.6],
         "text-size": 11,
-        "icon-allow-overlap": false
+        "icon-allow-overlap": false,
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(30, 30, 30, 1)",

--- a/style.json
+++ b/style.json
@@ -29,13 +29,13 @@
       "type": "vector",
       "tiles": ["https://tiles.nst.guide/contour_10m/{z}/{x}/{y}.pbf"],
       "minzoom": 11,
-      "maxzoom": 11
+      "maxzoom": 13
     },
     "contour_40ft": {
       "type": "vector",
       "tiles": ["https://tiles.nst.guide/contour_40ft/{z}/{x}/{y}.pbf"],
       "minzoom": 11,
-      "maxzoom": 11
+      "maxzoom": 13
     }
   },
   "sprite": "https://raw.githubusercontent.com/nst-guide/osm-liberty-topo/gh-pages/sprites/osm-liberty-topo",
@@ -145,9 +145,14 @@
       "id": "contour_index_ft",
       "type": "line",
       "source": "contour_40ft",
-      "source-layer": "contour_ft",
+      "source-layer": "contour_40ft",
       "minzoom": 0,
-      "filter": ["==", ["%", ["get", "ele_ft"], 200], 0],
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
       "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
@@ -159,9 +164,14 @@
       "id": "contour_index_m",
       "type": "line",
       "source": "contour_10m",
-      "source-layer": "contour_m",
+      "source-layer": "contour_10m",
       "minzoom": 0,
-      "filter": ["==", ["%", ["get", "ele_m"], 50], 0],
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -172,9 +182,14 @@
       "id": "contour_ft",
       "type": "line",
       "source": "contour_40ft",
-      "source-layer": "contour_ft",
+      "source-layer": "contour_40ft",
       "minzoom": 11,
-      "filter": ["!=", ["%", ["get", "ele_ft"], 200], 0],
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
       "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(179, 134, 89)",
@@ -186,9 +201,14 @@
       "id": "contour_m",
       "type": "line",
       "source": "contour_10m",
-      "source-layer": "contour_m",
+      "source-layer": "contour_10m",
       "minzoom": 11,
-      "filter": ["!=", ["%", ["get", "ele_m"], 50], 0],
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["!=", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["!=", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["!=", ["%", ["get", "ele_m"], 50], 0]]
+      ],
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -1452,8 +1472,13 @@
       "type": "symbol",
       "metadata": {},
       "source": "contour_40ft",
-      "source-layer": "contour_ft",
-      "filter": ["==", ["%", ["get", "ele_ft"], 200], 0],
+      "source-layer": "contour_40ft",
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_ft"], 800], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_ft"], 400], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_ft"], 200], 0]]
+      ],
       "layout": {
         "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
         "text-allow-overlap": false,
@@ -1477,8 +1502,13 @@
       "type": "symbol",
       "metadata": {},
       "source": "contour_10m",
-      "source-layer": "contour_m",
-      "filter": ["==", ["%", ["get", "ele_m"], 50], 0],
+      "source-layer": "contour_10m",
+      "filter": [
+        "any",
+        ["all", ["<=", ["zoom"], 11], ["==", ["%", ["get", "ele_m"], 200], 0]],
+        ["all", ["==", ["zoom"], 12], ["==", ["%", ["get", "ele_m"], 100], 0]],
+        ["all", [">=", ["zoom"], 13], ["==", ["%", ["get", "ele_m"], 50], 0]]
+      ],
       "layout": {
         "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
         "text-allow-overlap": false,

--- a/style.json
+++ b/style.json
@@ -25,9 +25,17 @@
       "maxzoom": 12,
       "encoding": "mapbox"
     },
-    "contours": {
+    "contour_10m": {
       "type": "vector",
-      "url": "https://tiles.nst.guide/contours/tile.json"
+      "tiles": ["https://tiles.nst.guide/contour_10m/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 11
+    },
+    "contour_40ft": {
+      "type": "vector",
+      "tiles": ["https://tiles.nst.guide/contour_40ft/{z}/{x}/{y}.pbf"],
+      "minzoom": 11,
+      "maxzoom": 11
     }
   },
   "sprite": "https://raw.githubusercontent.com/nst-guide/osm-liberty-topo/gh-pages/sprites/osm-liberty-topo",
@@ -134,13 +142,13 @@
       }
     },
     {
-      "id": "contour_index",
+      "id": "contour_index_ft",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
+      "source": "contour_40ft",
+      "source-layer": "contour_ft",
       "minzoom": 0,
-      "filter": ["all", [">", "ContourElevation", 0], ["==", "FCode", 10102]],
-      "layout": {"visibility": "visible"},
+      "filter": ["==", ["%", ["get", "ele_ft"], 200], 0],
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgb(166, 116, 66)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -148,13 +156,39 @@
       }
     },
     {
-      "id": "contour",
+      "id": "contour_index_m",
       "type": "line",
-      "source": "contours",
-      "source-layer": "Elev_Contour",
-      "minzoom": 7,
-      "filter": ["all", ["==", "FCode", 10101], [">", "ContourElevation", 0]],
-      "layout": {"visibility": "visible"},
+      "source": "contour_10m",
+      "source-layer": "contour_m",
+      "minzoom": 0,
+      "filter": ["==", ["%", ["get", "ele_m"], 50], 0],
+      "paint": {
+        "line-color": "rgb(166, 116, 66)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": 1.1
+      }
+    },
+    {
+      "id": "contour_ft",
+      "type": "line",
+      "source": "contour_40ft",
+      "source-layer": "contour_ft",
+      "minzoom": 11,
+      "filter": ["!=", ["%", ["get", "ele_ft"], 200], 0],
+      "layout": {"visibility": "none"},
+      "paint": {
+        "line-color": "rgb(179, 134, 89)",
+        "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
+        "line-width": {"stops": [[11, 0.4], [14, 0.6]]}
+      }
+    },
+    {
+      "id": "contour_m",
+      "type": "line",
+      "source": "contour_10m",
+      "source-layer": "contour_m",
+      "minzoom": 11,
+      "filter": ["!=", ["%", ["get", "ele_m"], 50], 0],
       "paint": {
         "line-color": "rgb(179, 134, 89)",
         "line-opacity": {"stops": [[11, 0.2], [14, 0.4]]},
@@ -1414,17 +1448,12 @@
       }
     },
     {
-      "id": "contour_label",
+      "id": "contour_label_ft",
       "type": "symbol",
       "metadata": {},
-      "source": "contours",
-      "source-layer": "Elev_Contour",
-      "filter": [
-        "all",
-        ["==", "$type", "LineString"],
-        ["==", "FCode", 10102],
-        [">", "ContourElevation", 0]
-      ],
+      "source": "contour_40ft",
+      "source-layer": "contour_ft",
+      "filter": ["==", ["%", ["get", "ele_ft"], 200], 0],
       "layout": {
         "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
         "text-allow-overlap": false,
@@ -1433,7 +1462,32 @@
         "symbol-placement": "line",
         "text-padding": 10,
         "text-rotation-alignment": "map",
-        "text-field": "{ContourElevation}",
+        "text-field": "{ele_ft}ft",
+        "text-font": ["Open Sans Regular"],
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgb(131, 66, 37)",
+        "text-halo-color": "hsla(0, 0%, 100%, 0.5)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "contour_label_m",
+      "type": "symbol",
+      "metadata": {},
+      "source": "contour_10m",
+      "source-layer": "contour_m",
+      "filter": ["==", ["%", ["get", "ele_m"], 50], 0],
+      "layout": {
+        "text-size": {"base": 1, "stops": [[15, 9.5], [20, 12]]},
+        "text-allow-overlap": false,
+        "symbol-avoid-edges": true,
+        "text-ignore-placement": false,
+        "symbol-placement": "line",
+        "text-padding": 10,
+        "text-rotation-alignment": "map",
+        "text-field": "{ele_m}m",
         "text-font": ["Open Sans Regular"],
         "visibility": "visible"
       },

--- a/style.json
+++ b/style.json
@@ -1762,7 +1762,7 @@
       }
     },
     {
-      "id": "poi_saddle",
+      "id": "poi_saddle_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1779,7 +1779,46 @@
             ["get", "name"],
             "\n",
             ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-            " ft"
+            "ft"
+          ],
+          ["has", "name"],
+          ["get", "name"],
+          "Pass"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "icon-size": {"stops": [[14, 0.65], [16, 1]]},
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_saddle_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 13,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "saddle"]],
+      "layout": {
+        "icon-image": "viewpoint_11",
+        "text-anchor": "top",
+        "text-field": [
+          "case",
+          ["all", ["has", "name"], ["has", "ele"]],
+          [
+            "concat",
+            ["get", "name"],
+            "\n",
+            ["to-string", ["round", ["get", "ele"]]],
+            "m"
           ],
           ["has", "name"],
           ["get", "name"],
@@ -1800,7 +1839,7 @@
       }
     },
     {
-      "id": "poi_peak_rank1",
+      "id": "poi_peak_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1822,7 +1861,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_peak_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "peak"]
+      ],
+      "layout": {
+        "icon-image": "mountain_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,
@@ -1838,7 +1916,7 @@
       }
     },
     {
-      "id": "poi_volcano_rank1",
+      "id": "poi_volcano_rank1_ft",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "mountain_peak",
@@ -1860,7 +1938,46 @@
           ["get", "name"],
           "\n",
           ["to-string", ["round", ["*", ["get", "ele"], 3.28084]]],
-          " ft"
+          "ft"
+        ],
+        "text-font": ["Open Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 11,
+        "icon-allow-overlap": false,
+        "visibility": "none"
+      },
+      "paint": {
+        "text-color": "rgba(30, 30, 30, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi_volcano_rank1_m",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "mountain_peak",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["!in", "name", "peak", ""],
+        ["has", "ele"],
+        ["has", "name"],
+        ["==", "class", "volcano"]
+      ],
+      "layout": {
+        "icon-image": "volcano_11",
+        "text-anchor": "top",
+        "text-field": [
+          "concat",
+          ["get", "name"],
+          "\n",
+          ["to-string", ["round", ["get", "ele"]]],
+          "m"
         ],
         "text-font": ["Open Sans Regular"],
         "text-max-width": 9,


### PR DESCRIPTION
Use new contours data generated from DEM using nst-guide/terrain. This allows toggling whether metric or imperial data are displayed. From looking at the network tab, it appears that if all the layers from a single source are set to `visibility: none`, then the request isn't sent. 

Don't merge until the full contours have been generated.

Todo: 

- [x] include metric layers for mountain peaks, passes